### PR TITLE
fix: DB 연결 오류 및 Bad Gateway 문제 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,12 @@ services:
     environment:
       - DEBUG=${DEBUG:-False}
       - SECRET_KEY=${SECRET_KEY:-your-secret-key-here}
-      - DATABASE_URL=mysql://${MYSQL_USER:-django_user}:${MYSQL_PASSWORD:-django_password}@db:3306/${MYSQL_DATABASE:-email_reports}
+      # 개별 DB 환경 변수 추가 (settings.py에서 사용)
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-email_reports}
+      - MYSQL_USER=${MYSQL_USER:-django_user}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-django_password}
+      - MYSQL_HOST=db
+      - MYSQL_PORT=3306
       - ALLOWED_HOSTS=${ALLOWED_HOSTS:-localhost,127.0.0.1}
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:10005,http://localhost:10003}
     depends_on:

--- a/docker/mysql/init.sql
+++ b/docker/mysql/init.sql
@@ -6,7 +6,8 @@ CREATE DATABASE IF NOT EXISTS email_reports CHARACTER SET utf8mb4 COLLATE utf8mb
 
 -- 사용자 생성 및 권한 설정
 -- MySQL 8.0에서는 CREATE USER가 필수
-CREATE USER IF NOT EXISTS 'django_user'@'%' IDENTIFIED BY 'django_password';
+-- PyMySQL 호환성을 위해 mysql_native_password 사용
+CREATE USER IF NOT EXISTS 'django_user'@'%' IDENTIFIED WITH mysql_native_password BY 'django_password';
 GRANT ALL PRIVILEGES ON email_reports.* TO 'django_user'@'%';
 FLUSH PRIVILEGES;
 


### PR DESCRIPTION
- docker-compose.yml: 개별 DB 환경 변수 추가 (MYSQL_USER, MYSQL_PASSWORD 등)
- settings.py가 개별 환경 변수를 요구하므로 DATABASE_URL 대신 개별 변수 전달
- docker/mysql/init.sql: mysql_native_password로 인증 플러그인 변경 (PyMySQL 호환성)
- 이로 인해 Backend DB 연결 성공 → Nginx 502 Bad Gateway 해결