### PR TITLE
fix: Frontend 포트를 10005로 통일

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -34,7 +34,7 @@ COPY . .
 
 EXPOSE 10005
 
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+CMD ["npm", "run", "dev"]
 
 # Stage 3: Production with Nginx
 FROM nginx:alpine AS production

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --host 0.0.0.0 --port 3000",
+    "dev": "vite --host 0.0.0.0 --port 10005",
     "build": "tsc && vite build",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",


### PR DESCRIPTION
- package.json: dev 스크립트 포트를 3000에서 10005로 변경
- Dockerfile: 불필요한 CLI 인자 제거 (package.json 사용)
- Nginx가 frontend:10005로 프록시하므로 포트 일치 필요
- 이로 인해 Frontend 502 Bad Gateway 해결